### PR TITLE
fix: usage in environment without window

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,16 +1,17 @@
-/**
+/*!
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+
 import { loadState } from '@nextcloud/initial-state'
 
 export function getCapabilities(): Object {
 	try {
 		return loadState('core', 'capabilities')
 	} catch (error) {
-		if (!('_oc_capabilities' in window)) {
+		if (!('_oc_capabilities' in globalThis)) {
 			return {}
 		}
-		return window['_oc_capabilities'] as Object
+		return globalThis['_oc_capabilities'] as Object
 	}
 }


### PR DESCRIPTION
Allows using the package in an environment without `window`. `loadState` fails anyway, but there could be `_oc_capabilities` global

Alternative: wrap over `try` as well and return `{}`