### PR TITLE
ci: update npm-publish.yml workflow from template

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,17 +13,18 @@ on:
     types: [published]
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
-  packages: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     name: Build and publish to npm
+    environment: npm-publish
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -32,9 +33,10 @@ jobs:
         id: versions
 
       - name: Set up node
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ steps.versions.outputs.node-version }}
+          registry-url: https://registry.npmjs.org
 
       - name: Set up npm
         run: npm i -g 'npm@${{ steps.versions.outputs.package-manager-version }}'
@@ -54,7 +56,7 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: 0
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build --if-present
 
       - name: Fetch latest tag
@@ -73,8 +75,6 @@ jobs:
 
       - name: Publish
         run: |
-          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           npm publish --tag $RELEASE_GROUP
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_GROUP: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha')) && 'next' || ((steps.latest-tag.outputs.LATEST_TAG != github.event.release.tag_name) && 'stable' || 'latest') }}


### PR DESCRIPTION
Automated update of the npm-publish.yml workflow from https://github.com/nextcloud-libraries/.github triggered by susnux